### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/common/src/vulkan_to_string.cc
+++ b/common/src/vulkan_to_string.cc
@@ -37,7 +37,7 @@ to_string(QueueFamilyIndices const & ind) -> std::string
 auto
 to_string(VkPhysicalDeviceProperties const & prop) -> std::string
 {
-    auto const [major, minor, patch] = VulkanVersion::from_u32(prop.apiVersion);
+    auto const [major, minor, patch] = VulkanVersion::from(prop.apiVersion);
     return fmt::format("Device Name: {}\n"
                        "Device Type: {}\n"
                        "Device ID: {}\n"

--- a/common/src/vulkan_version.hh
+++ b/common/src/vulkan_version.hh
@@ -7,7 +7,7 @@ struct VulkanVersion {
     uint16_t patch;
 
     constexpr static auto
-    from_u32(uint32_t version) -> VulkanVersion
+    from(uint32_t version) -> VulkanVersion
     {
         VulkanVersion result{};
         result.major = version >> 22;

--- a/vulkan_wrappers/include/vulkan_surface_wrapper.hh
+++ b/vulkan_wrappers/include/vulkan_surface_wrapper.hh
@@ -3,8 +3,8 @@
 
 #include "handle_wrapper.hh"
 
-#include <vulkan/vulkan.hpp>
 #include <optional>
+#include <vulkan/vulkan.hpp>
 
 namespace glfw {
 struct WindowWrapper;

--- a/vulkan_wrappers/src/vulkan_surface_wrapper.cc
+++ b/vulkan_wrappers/src/vulkan_surface_wrapper.cc
@@ -1,8 +1,8 @@
 #include "vulkan_surface_wrapper.hh"
 
-#include "vulkan_instance_wrapper.hh"
 #include "fmt/core.h"
 #include "glfw_window_wrapper.hh"
+#include "vulkan_instance_wrapper.hh"
 
 #include <GLFW/glfw3.h>
 


### PR DESCRIPTION
For some reason it was inactive when building the previous PR